### PR TITLE
Switch RMA API requests to Bearer auth headers.

### DIFF
--- a/classes/class-RMA_WC_API.php
+++ b/classes/class-RMA_WC_API.php
@@ -93,6 +93,30 @@ if ( !class_exists('RMA_WC_API') ) {
 		}
 
 		/**
+		 * Build authenticated request args for RMA API requests.
+		 *
+		 * @param array $args Optional request args.
+		 * @return array
+		 */
+		private static function get_authenticated_http_args( array $args = array() ): array {
+			$http_args = wp_parse_args( $args, array( 'timeout' => 120 ) );
+
+			$headers = array();
+			if ( isset( $http_args['headers'] ) && is_array( $http_args['headers'] ) ) {
+				$headers = $http_args['headers'];
+			}
+
+			$http_args['headers'] = array_merge(
+				$headers,
+				array(
+					'Authorization' => 'Bearer ' . RMA_APIKEY,
+				)
+			);
+
+			return $http_args;
+		}
+
+		/**
 		 * Read customer list from RMA
 		 *
 		 * @return mixed
@@ -114,8 +138,8 @@ if ( !class_exists('RMA_WC_API') ) {
 
 			}
 
-			$url       = self::get_caller_url() . RMA_MANDANT . '/customers?api_key=' . RMA_APIKEY;
-			$response  = wp_remote_get( $url );
+			$url       = self::get_caller_url() . RMA_MANDANT . '/customers';
+			$response  = wp_remote_get( $url, self::get_authenticated_http_args() );
 
 			// Check response code
 			if ( 200 <> wp_remote_retrieve_response_code( $response ) ){
@@ -136,7 +160,9 @@ if ( !class_exists('RMA_WC_API') ) {
 				$response = (array) $response['http_response'];
 
 				foreach ( $response as $object ) {
-					$message .= ' ' . $object->url;
+					if ( null !== $object ) {
+						$message .= ' ' . $object->url;
+					}
 					break;
 				}
 
@@ -227,9 +253,9 @@ if ( !class_exists('RMA_WC_API') ) {
 
 			}
 
-			$url       = self::get_caller_url() . RMA_MANDANT . '/parts?api_key=' . RMA_APIKEY;
+			$url       = self::get_caller_url() . RMA_MANDANT . '/parts';
 
-			$response  = wp_remote_get( $url );
+			$response  = wp_remote_get( $url, self::get_authenticated_http_args() );
 
 			// Check response code
 			if ( 200 <> wp_remote_retrieve_response_code( $response ) ){
@@ -240,7 +266,9 @@ if ( !class_exists('RMA_WC_API') ) {
 				$response = (array) $response[ 'http_response' ];
 
 				foreach ( $response as $object ) {
-					$message .= ' ' . $object->url;
+					if ( null !== $object ) {
+						$message .= ' ' . $object->url;
+					}
 					break;
 				}
 
@@ -706,7 +734,7 @@ if ( !class_exists('RMA_WC_API') ) {
 		 */
 		public static function create_xml_content( array $data, array $order_ids, bool $collective_invoice = false ): bool {
 
-			$url  = self::get_caller_url() . RMA_MANDANT . '/invoices?api_key=' . RMA_APIKEY;
+			$url  = self::get_caller_url() . RMA_MANDANT . '/invoices';
 
 			//create the xml document
 			$xml  = new DOMDocument('1.0', 'UTF-8');
@@ -830,7 +858,7 @@ if ( !class_exists('RMA_WC_API') ) {
 			$data   = self::$method( $id );
 
 			// build REST api url for Run my Accounts
-			$caller_url_customer = self::get_caller_url() . RMA_MANDANT . '/customers?api_key=' . RMA_APIKEY;
+			$caller_url_customer = self::get_caller_url() . RMA_MANDANT . '/customers';
 
 			//create the xml document
 			$xml_doc = new DOMDocument('1.0', 'UTF-8');
@@ -928,11 +956,13 @@ if ( !class_exists('RMA_WC_API') ) {
 
 			$response = wp_safe_remote_post(
 				$url,
-				array(
-					'headers'          => array(
+				self::get_authenticated_http_args(
+					array(
+						'headers'          => array(
 						'Content-Type' => 'application/xml'
-					),
-					'body'             => $xml
+						),
+						'body'             => $xml
+					)
 				)
 			);
 

--- a/classes/class-RMA_WC_Payment.php
+++ b/classes/class-RMA_WC_Payment.php
@@ -84,7 +84,7 @@ class RMA_WC_Payment {
 	    $this->invoice = $order->get_meta('_rma_invoice', true );
 
         $data = self::get_payment_details();
-        $url  = RMA_WC_API::get_caller_url() . RMA_MANDANT . '/invoices/' . $this->invoice . '/payments?api_key=' . RMA_APIKEY;
+        $url  = RMA_WC_API::get_caller_url() . RMA_MANDANT . '/invoices/' . $this->invoice . '/payments';
 
         //create the xml document
         $xml  = new DOMDocument('1.0', 'UTF-8');


### PR DESCRIPTION
Remove API keys from request URLs, centralize authenticated request args, and guard URL logging against null response objects to avoid fatal errors.

Co-Authored by CursorAI