### PR TITLE
Show invoices and invoice status in order list, show invoices to users

### DIFF
--- a/classes/class-RMA_WC_API.php
+++ b/classes/class-RMA_WC_API.php
@@ -204,6 +204,228 @@ if ( !class_exists('RMA_WC_API') ) {
 		}
 
 		/**
+		 * Read info on one customer.
+		 *
+		 * @param string $rma_customer_id Run my Accounts customer number.
+		 * @return array|false
+		 */
+		public function get_customer( $rma_customer_id ) {
+
+			if ( !RMA_MANDANT || !RMA_APIKEY ) {
+
+				$log_values = array(
+					'status' => 'error',
+					'section_id' => '',
+					'section' => esc_html_x('Get Customer', 'Log Section', 'run-my-accounts-for-woocommerce'),
+					'mode' => self::rma_mode(),
+					'message' => esc_html__('Missing API data', 'run-my-accounts-for-woocommerce') );
+
+				self::write_log($log_values);
+
+				return false;
+
+			}
+
+			$url      = self::get_caller_url() . RMA_MANDANT . '/customers/' . sanitize_key( $rma_customer_id ) . '?api_key=' . RMA_APIKEY;
+			$response = wp_remote_get( $url );
+
+			// Check response code.
+			if ( 200 <> wp_remote_retrieve_response_code( $response ) ) {
+
+				$message = esc_html__( 'Response Code', 'run-my-accounts-for-woocommerce') . ' '. wp_remote_retrieve_response_code( $response );
+				$message .= ' '. wp_remote_retrieve_response_message( $response );
+
+				if ( is_wp_error( $response ) ) {
+
+					$error_string = sanitize_text_field( $response->get_error_message() );
+					echo '<div id="message" class="error"><p>' . esc_html( $error_string ) . '</p></div>';
+
+					return false;
+
+				}
+
+				$response = (array) $response['http_response'];
+
+				foreach ( $response as $object ) {
+					$message .= ' ' . $object->url;
+					break;
+				}
+
+				$log_values = array(
+					'status' => 'error',
+					'section_id' => '',
+					'section' => esc_html_x('Get Customer', 'Log Section', 'run-my-accounts-for-woocommerce'),
+					'mode' => self::rma_mode(),
+					'message' => $message );
+
+				self::write_log($log_values);
+
+				return false;
+			}
+
+			libxml_use_internal_errors( true );
+			$body = wp_remote_retrieve_body( $response );
+			$xml  = simplexml_load_string( $body );
+
+			if ( !$xml ) {
+				return false;
+			}
+
+			$customer = json_decode( json_encode( (array)$xml ), true );
+			return ( ! empty( $customer ) ? $customer : false );
+		}
+
+		/**
+		 * Read invoices for one customer.
+		 *
+		 * @param string|null $rma_customer_id Run my Accounts customer number.
+		 * @param string $from YYYY-MM-DD.
+		 * @param string|null $to YYYY-MM-DD.
+		 * @return array|false
+		 */
+		public function get_customer_invoices( $rma_customer_id = null, $from = '1900-01-01', $to = null ) {
+
+			if ( !RMA_MANDANT || !RMA_APIKEY ) {
+
+				$log_values = array(
+					'status' => 'error',
+					'section_id' => '',
+					'section' => esc_html_x('Get Customer Invoice', 'Log Section', 'run-my-accounts-for-woocommerce'),
+					'mode' => self::rma_mode(),
+					'message' => esc_html__('Missing API data', 'run-my-accounts-for-woocommerce') );
+
+				self::write_log($log_values);
+
+				return false;
+
+			}
+
+			$url = self::get_caller_url() . RMA_MANDANT . '/invoices?api_key=' . RMA_APIKEY . '&from=' . sanitize_key( $from );
+			if ( ! empty( $rma_customer_id ) ) {
+				$url .= '&customer_number=' . sanitize_key( $rma_customer_id );
+			}
+			if ( ! empty( $to ) ) {
+				$url .= '&to=' . sanitize_key( $to );
+			}
+
+			$response = wp_remote_get( $url );
+
+			// Check response code.
+			if ( 200 <> wp_remote_retrieve_response_code( $response ) ) {
+
+				$message = esc_html__( 'Response Code', 'run-my-accounts-for-woocommerce') . ' '. wp_remote_retrieve_response_code( $response );
+				$message .= ' '. wp_remote_retrieve_response_message( $response );
+
+				if ( is_wp_error( $response ) ) {
+
+					$error_string = sanitize_text_field( $response->get_error_message() );
+					echo '<div id="message" class="error"><p>' . esc_html( $error_string ) . '</p></div>';
+
+					return false;
+
+				}
+
+				$response = (array) $response['http_response'];
+
+				foreach ( $response as $object ) {
+					$message .= ' ' . $object->url;
+					break;
+				}
+
+				$log_values = array(
+					'status' => 'error',
+					'section_id' => '',
+					'section' => esc_html_x('Get Customer Invoice', 'Log Section', 'run-my-accounts-for-woocommerce'),
+					'mode' => self::rma_mode(),
+					'message' => $message );
+
+				self::write_log($log_values);
+
+				return false;
+			}
+
+			libxml_use_internal_errors( true );
+			$body = wp_remote_retrieve_body( $response );
+			$xml  = simplexml_load_string( $body );
+
+			if ( false === $xml ) {
+				return false;
+			}
+
+			$invoices = array();
+			foreach ( $xml->invoice as $invoice ) {
+				$invoices[] = json_decode( json_encode( (array) $invoice ), true );
+			}
+
+			return array( 'invoice' => $invoices );
+		}
+
+		/**
+		 * Fetch PDF file for invoice.
+		 *
+		 * @param string $rma_invoice_number Invoice number.
+		 * @return string|false
+		 */
+		public function get_invoice_pdf( $rma_invoice_number ) {
+
+			if ( !RMA_MANDANT || !RMA_APIKEY ) {
+
+				$log_values = array(
+					'status' => 'error',
+					'section_id' => '',
+					'section' => esc_html_x('Get Invoice PDF', 'Log Section', 'run-my-accounts-for-woocommerce'),
+					'mode' => self::rma_mode(),
+					'message' => esc_html__('Missing API data', 'run-my-accounts-for-woocommerce') );
+
+				self::write_log($log_values);
+
+				return false;
+
+			}
+
+			$requested_rma_invoice_number = strtoupper( sanitize_key( $rma_invoice_number ) );
+
+			// Verify this invoice belongs to current user.
+			$details_url      = self::get_caller_url() . RMA_MANDANT . '/invoices/' . $requested_rma_invoice_number . '?api_key=' . RMA_APIKEY;
+			$details_response = wp_remote_get( $details_url );
+
+			if ( is_wp_error( $details_response ) ) {
+				return false;
+			}
+
+			libxml_use_internal_errors( true );
+			$details_body = wp_remote_retrieve_body( $details_response );
+			$details_xml  = simplexml_load_string( $details_body );
+			if ( false === $details_xml ) {
+				return false;
+			}
+
+			$invoice          = json_decode( json_encode( (array) $details_xml ), true );
+			$rma_user_remote  = $invoice['customer']['customernumber'] ?? '';
+			$rma_user_current = get_user_meta( get_current_user_id(), 'rma_customer', true );
+			if ( empty( $rma_user_remote ) || $rma_user_remote !== $rma_user_current ) {
+				return false;
+			}
+
+			$url      = self::get_caller_url() . RMA_MANDANT . '/invoices/' . $requested_rma_invoice_number . '/pdf?api_key=' . RMA_APIKEY;
+			$response = wp_remote_get( $url );
+
+			// Check response code.
+			if ( 200 <> wp_remote_retrieve_response_code( $response ) ) {
+				return false;
+			}
+
+			$body         = wp_remote_retrieve_body( $response );
+			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+
+			if ( false === strpos( (string) $content_type, 'application/pdf' ) ) {
+				return false;
+			}
+
+			return ( ! empty( $body ) ? $body : false );
+		}
+
+		/**
 		 * Read parts list from RMA
 		 *
 		 * @return mixed

--- a/classes/class-RMA_WC_Backend.php
+++ b/classes/class-RMA_WC_Backend.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * class-backend.php
- *  
+ *
  * @author      Sandro Lucifora
  * @copyright   (c) 2018, Openstream Internet Solutions
  * @link        https://www.openstream.ch/
  * @package     RunmyAccountsforWooCommerce
- * @since       1.0  
+ * @since       1.0
  */
 
 if ( !defined('ABSPATH' ) ) exit;
@@ -19,13 +19,15 @@ if (!class_exists('RMA_WC_Backend')) {
     class RMA_WC_Backend extends RMA_WC_Backend_Abstract {
 
         /**
-         * Construct  
+         * Construct
          */
         public function __construct() {
 
             add_action( 'admin_init', array($this, 'admin_init'));
             add_action( 'plugins_loaded', array($this, 'plugins_loaded'));
             add_action( 'plugins_loaded', array($this, 'plugins_loaded_settings'), 1);
+
+            add_filter( 'http_request_timeout', array($this, 'set_timeout'));
 
         }
 
@@ -34,8 +36,8 @@ if (!class_exists('RMA_WC_Backend')) {
          */
         static function activate() {
             /**
-             * set_transient() WP Since: 2.8  
-             * https://codex.wordpress.org/Function_Reference/set_transient  
+             * set_transient() WP Since: 2.8
+             * https://codex.wordpress.org/Function_Reference/set_transient
              */
             set_transient('rma-wc-page-activated', 1, 30);
         }
@@ -45,16 +47,17 @@ if (!class_exists('RMA_WC_Backend')) {
          */
         static function deactivate() {
             wp_clear_scheduled_hook( 'run_my_accounts_collective_invoice' );
+            wp_clear_scheduled_hook( 'update_invoice_status' );
         }
 
-	    /**
-	     * Uninstall - is triggered when register_uninstall_hook() is called, but we do it already in rma-wc.php
-	     */
-	    public function uninstall() {
+        /**
+         * Uninstall - is triggered when register_uninstall_hook() is called, but we do it already in rma-wc.php
+         */
+        public function uninstall() {
 
-		    $this->delete(); // Delete
+            $this->delete(); // Delete
 
-	    }
+        }
 
         /**
          * Admin Init - we initiate everything we need
@@ -81,8 +84,8 @@ if (!class_exists('RMA_WC_Backend')) {
 
             /**
              * We check whether there is transient. If not, we will do it here
-             * get_transient() WP Since: 2.8 
-             * https://codex.wordpress.org/Function_Reference/get_transient 
+             * get_transient() WP Since: 2.8
+             * https://codex.wordpress.org/Function_Reference/get_transient
              */
             if (!get_transient('rma-wc-page-activated')) {
                 return;
@@ -90,20 +93,20 @@ if (!class_exists('RMA_WC_Backend')) {
 
             /**
              * We delete the transient because we do not want the welcome page to be called again and again
-             * delete_transient() WP Since: 2.8 
-             * https://codex.wordpress.org/Function_Reference/delete_transient 
+             * delete_transient() WP Since: 2.8
+             * https://codex.wordpress.org/Function_Reference/delete_transient
              */
             delete_transient('rma-wc-page-activated');
 
             /**
              * here we redirect to the settings page
-             * wp_redirect() WP Since: 1.5.1 
-             * https://codex.wordpress.org/Function_Reference/wp_redirect 
+             * wp_redirect() WP Since: 1.5.1
+             * https://codex.wordpress.org/Function_Reference/wp_redirect
              */
             wp_redirect(
                     /**
-                     * admin_url() WP Since:2.6.0 
-                     * https://codex.wordpress.org/Function_Reference/admin_url 
+                     * admin_url() WP Since:2.6.0
+                     * https://codex.wordpress.org/Function_Reference/admin_url
                      */
                     admin_url('admin.php?page=rma-wc')
             );
@@ -129,6 +132,11 @@ if (!class_exists('RMA_WC_Backend')) {
 
         }
 
+        /** Set a high API timeout */
+        public function set_timeout() {
+            return 120;
+        }
+
     }
 
-} 
+}

--- a/classes/class-RMA_WC_Backend.php
+++ b/classes/class-RMA_WC_Backend.php
@@ -27,8 +27,6 @@ if (!class_exists('RMA_WC_Backend')) {
             add_action( 'plugins_loaded', array($this, 'plugins_loaded'));
             add_action( 'plugins_loaded', array($this, 'plugins_loaded_settings'), 1);
 
-            add_filter( 'http_request_timeout', array($this, 'set_timeout'));
-
         }
 
         /**
@@ -130,11 +128,6 @@ if (!class_exists('RMA_WC_Backend')) {
 
             return $plugin_data[ 'Version' ];
 
-        }
-
-        /** Set a high API timeout */
-        public function set_timeout() {
-            return 120;
         }
 
     }

--- a/classes/class-RMA_WC_Backend_Abstract.php
+++ b/classes/class-RMA_WC_Backend_Abstract.php
@@ -280,7 +280,8 @@ if ( !class_exists('RMA_WC_Backend_Abstract') ) {
 		    switch ( $column ) {
 			    case 'rma_invoice' :
 
-				    echo $wc_order_obj->get_meta( '_rma_invoice', true );
+                    $invoice_number_wc = $wc_order_obj->get_meta( '_rma_invoice', true );
+                    echo esc_html( $invoice_number_wc );
 
 			    default:
 		    }

--- a/classes/class-RMA_WC_Invoice.php
+++ b/classes/class-RMA_WC_Invoice.php
@@ -1,0 +1,484 @@
+<?php
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+if ( ! defined('ABSPATH')) exit;
+
+/**
+ * Class for reporting on the invoice status
+ *
+ * @since 1.7.0
+ */
+class RMA_WC_Invoice {
+
+	private $settings;
+
+	public function __construct() {
+        add_action( 'admin_init', array($this, 'admin_init_hooks'));
+        add_action( 'init', array($this, 'init_hooks'));
+
+		add_action( 'wp_head', array( $this, 'check_invoices' ) );
+
+		// update order status once per hour and display it on the admin and user order overview.
+		add_action( 'init', array( $this, 'maybe_create_schedule_update_invoice_status_event' ) );
+		add_action( 'update_invoice_status', array( $this, 'hourly_update_invoice_status' ) );
+	}
+
+
+
+	public function admin_init_hooks() {
+
+				// allow order query by invoice number.
+				add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', array( $this, 'handle_invoice_number_query_var' ), 10, 2 );
+
+
+
+
+				// Add invoice column to order list.
+		$is_hpos_enabled = class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled();
+		if ( ! $is_hpos_enabled ) {
+
+			// add status column to order page
+                    add_filter( 'manage_edit-shop_order_columns', array( $this, 'add_status_column_to_order_table' ) , 20);
+			add_action( 'manage_shop_order_posts_custom_column', array( $this, 'add_status_value_to_order_table_row' ), 10, 2 );
+
+			// allow filtering for order invoice status
+			add_action( 'restrict_manage_posts', array( $this, 'filter_status_column' ), 25, 2 );
+			add_action( 'pre_get_posts', array( $this, 'filter_orders_legacy' ), 25, 2 ); // Legacy.
+
+		} else {
+			// HPOS Hooks.
+
+			// add status column to order page
+                    add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_status_column_to_order_table' ) , 20);
+			add_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this, 'add_status_value_to_order_table_row' ), 10, 2 );
+
+			// allow filtering for order invoice status
+			add_action( 'woocommerce_order_list_table_prepare_items_query_args', array( $this, 'filter_orders_hpos' ), 25, 2 ); // HPOS.
+			add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'filter_status_column' ), 25, 2 );
+
+		}
+
+              
+
+
+	}
+
+	public function init_hooks() {
+
+			// User profile invoice info
+
+				// Add endpoints
+				add_rewrite_endpoint( 'invoices', EP_ROOT | EP_PAGES );
+				add_filter( 'query_vars', array( $this, 'my_invoices_query_vars' ) );
+				// Menu entry
+				add_filter( 'woocommerce_account_menu_items', array( $this, 'my_invoices_my_account_menu_items' ) );
+				add_action( 'woocommerce_account_invoices_endpoint', array( $this, 'my_invoices_endpoint_content' ) );
+				// Template for invoice list
+				add_filter( 'theme_page_templates', array( $this, 'add_account_invoices_template' ) );
+				// PDF Download
+				add_action( 'template_redirect', array( $this, 'invoice_pdf_download' ) );
+	}
+
+
+	/**
+	 * Checks the invoices for the currently logged-in user and adds notices for overdue or unpaid invoices.
+	 *
+	 * This function retrieves the invoices for the logged-in user from the transient cache or fetches them via the RMA_WC_API if not cached.
+	 * It then filters the invoices to identify those that are overdue or unpaid and adds appropriate notices to the WooCommerce session.
+	 *
+	 * @return string|null Returns 'overdue' if there are overdue invoices, 'unpaid' if there are unpaid invoices, or null if all invoices are paid.
+	 */
+	public function check_invoices() {
+
+		if ( did_action( 'woocommerce_init' ) === 1 && is_user_logged_in() && isset( WC()->session ) && WC()->session->has_session() ) {
+
+			$warning_icon = '<span class="dashicons dashicons-warning"></span>';
+			$invoice_url  = wc_get_endpoint_url( 'invoices', '', get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) );
+			// translators: %s = url.
+			$overdue_message = '<span color="red">' . $warning_icon . sprintf( __( 'You have overdue <a href="%s">invoices</a>', 'rma-wc' ), $invoice_url ) . '</span>';
+
+			// translators: %s = url.
+			$unpaid_message = sprintf( __( 'You have unpaid <a href="%s">invoices</a>', 'rma-wc' ), $invoice_url );
+
+			// Only set the message once.
+			if ( wc_has_notice( $overdue_message, 'notice' ) || wc_has_notice( $unpaid_message, 'notice' ) ) {
+				return;
+			}
+
+			$user_id         = get_current_user_id();
+			$rma_customer_id = get_user_meta( $user_id, 'rma_customer', true );
+
+			if ( ! empty( $rma_customer_id ) ) {
+
+				$invoices = get_transient( 'invoices_' . $rma_customer_id );
+				if ( false === $invoices ) {
+					$RMA_WC_API = new RMA_WC_API();
+					$invoices   = $RMA_WC_API->get_customer_invoices( $rma_customer_id );
+					unset( $RMA_WC_API );
+					if ( false === $invoices ) {
+						return;
+					}
+					set_transient( 'invoices_' . $rma_customer_id, $invoices, HOUR_IN_SECONDS );
+				}
+
+				$overdue_invoices = array_filter(
+					$invoices['invoice'],
+					function( $i ) {
+						return 'OVERDUE' === $i['status'] && 0 < $i['amount'];
+					}
+				);
+
+				$unpaid_invoices = array_filter(
+					$invoices['invoice'],
+					function( $i ) {
+						return 'PAID' !== $i['status'] && 0 < $i['amount'];
+					}
+				);
+
+				if ( ! empty( $overdue_invoices ) ) {
+					wc_add_notice( $overdue_message, 'notice' );
+					return 'overdue';
+
+				} elseif ( ! empty( $unpaid_invoices ) ) {
+					// translators: %s = url.
+					wc_add_notice( $unpaid_message, 'notice' );
+					return 'unpaid';
+
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Allow querying orders by invoice number.
+	 *
+	 * https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#adding-custom-parameter-support
+	 * Handle a custom 'customvar' query var to get orders with the 'customvar' meta.
+	 *
+	 * @param array $query - Args for WP_Query.
+	 * @param array $query_vars - Query vars from WC_Order_Query.
+	 * @return array modified $query
+	 */
+	function handle_invoice_number_query_var( $query, $query_vars ) {
+		if ( ! empty( $query_vars['invoice_number'] ) ) {
+			$query['meta_query'][] = array(
+                    'key' => '_rma_invoice',
+				'value' => esc_attr( $query_vars['invoice_number'] ),
+			);
+		}
+
+		return $query;
+	}
+
+		/**
+		 * Create scheduler for hourly order status update.
+		 * Schedules the event if it's NOT already scheduled.
+		 */
+        public function maybe_create_schedule_update_invoice_status_event( ) {
+            if ( ! wp_next_scheduled ( 'update_invoice_status' ) ) {
+			wp_schedule_event( time(), 'hourly', 'update_invoice_status' );
+		}
+	}
+
+		/**
+		 * Update order status
+         * 
+		 */
+        public function hourly_update_invoice_status( ) {
+            $RMA_WC_API = new RMA_WC_API();
+		$status_array = $RMA_WC_API->get_invoice_status();
+		if ( false !== $status_array ) {
+                foreach( $status_array as $invoice_number => $status ) {
+                    // Guard against empty/invalid invoice keys: an empty key would query broadly and corrupt statuses.
+                    if ( ! is_scalar( $invoice_number ) ) {
+                        continue;
+                    }
+                    $invoice_number = trim( (string) $invoice_number );
+                    if ( '' === $invoice_number ) {
+                        continue;
+                    }
+                    $orders = wc_get_orders( array( 'invoice_number' => $invoice_number ) );
+                    foreach( $orders as $order ) {
+                        $debug_var = (json_encode(array(
+                            'id' => $order->get_id(),
+                            'inv'=> $invoice_number,
+                            'stat'=>$status,
+                            'array'=>$status_array
+                        )));
+
+					$order->update_meta_data( '_rma_invoice_status', sanitize_text_field( $status ) );
+                        $order->update_meta_data('_rma_invoice_status_timestamp', current_datetime()->format('c') );
+					$order->save_meta_data();
+				}
+			}
+		} else {
+			$log_values = array(
+				'status'     => 'error',
+				'section_id' => '',
+				'section'    => esc_html_x( 'Get Invoice Status', 'Log Section', 'rma-wc' ),
+				'mode'       => RMA_WC_API::rma_mode(),
+				'message'    => esc_html_x( 'Invoice Status could not be read.', 'Log Section', 'rma-wc' ),
+			);
+
+			( new RMA_WC_API() )->write_log( $log_values );
+		}
+
+		unset( $RMA_WC_API );
+	}
+
+
+		/**
+		 * Add status column to order table
+		 *
+		 * @param $columns
+		 *
+		 * @return array
+		 */
+	public function add_status_column_to_order_table( $columns ) {
+
+		// $this->update_invoice_status();
+		$columns = RMA_WC_Frontend::array_insert( $columns, 'rma_invoice', 'rma_invoice_status', __( 'Invoice Status', 'rma-wc' ) );
+		return $columns;
+	}
+
+	public function add_status_value_to_order_table_row( $column, $order ) {
+
+		global $post;
+
+		switch ( $column ) {
+
+                case 'rma_invoice_status' :
+				echo '<mark class="order-status" title="';
+				echo __( 'Last updated: ', 'rma-wc' );
+                    echo wp_date( get_option( 'date_format' ),strtotime( $order->get_meta('_rma_invoice_status_timestamp', true ) ) );
+				echo ' ';
+                    echo wp_date( get_option( 'time_format' ),strtotime( $order->get_meta( '_rma_invoice_status_timestamp', true ) ) );
+				echo '"><span>';
+				echo esc_html( $order->get_meta( '_rma_invoice_status', true ) );
+                    echo "</span></mark>";
+
+			default:
+		}
+
+
+	}
+
+	public function filter_status_column( $post_type, $which ) {
+
+            if( 'shop_order' !== $post_type ) {
+			return;
+		}
+
+            $status_field = isset( $_GET[ 'rma_status_field' ] ) ? $_GET[ 'rma_status_field' ] : '';
+
+		?>
+				<select name="rma_status_field">
+					<option selected="selected" value="any" <?php selected( $status_field, 'any' ); ?>>Any Invoice Status</option>
+					<option value="invoiced" <?php selected( $status_field, 'invoiced' ); ?>>Invoiced</option>
+					<option value="empty" <?php selected( $status_field, 'empty' ); ?>>No Invoice</option>
+				</select>
+			<?php
+	}
+
+	public function filter_orders_hpos( $query_args ) {
+
+            $status_field = isset( $_GET[ 'rma_status_field' ] ) ? $_GET[ 'rma_status_field' ] : '';
+
+		if ( 'any' === $status_field ) {
+			return $query_args;
+		}
+		$meta_query = $query_args['meta_query'] ?? array();
+		if ( 'empty' === $status_field ) {
+			$meta_query[] = array(
+				'relation' => 'OR',
+				array(
+					'key'     => '_rma_invoice_status',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'   => '_rma_invoice_status',
+					'value' => '',
+				),
+			);
+		}
+
+		if ( 'invoiced' === $status_field ) {
+			$meta_query[] = array(
+                        'key'   => '_rma_invoice_status',
+                        'value' => '',
+				'compare' => '!=',
+			);
+		}
+		$query_args['meta_query'] = $meta_query;
+
+
+		return $query_args;
+	}
+
+	public function filter_orders_legacy( $query ) {
+
+            if( ! is_admin() ) {
+			return;
+		}
+
+		global $pagenow;
+		// just being super-accurate here
+            if( 'edit.php' !== $pagenow || 'shop_order' !== $query->get( 'post_type' ) ) {
+			return;
+		}
+
+            $status_field = isset( $_GET[ 'rma_status_field' ] ) ? $_GET[ 'rma_status_field' ] : '';
+
+		if ( 'any' === $status_field ) {
+			return $query;
+		}
+            $meta_query = (array)$query->get('meta_query');
+		if ( 'empty' === $status_field ) {
+			$meta_query[] = array(
+				'relation' => 'OR',
+				array(
+                        'key' => '_rma_invoice_status',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+                        'key' => '_rma_invoice_status',
+					'value' => '',
+                    )
+			);
+		}
+
+		if ( 'invoiced' === $status_field ) {
+			$meta_query[] = array(
+				array(
+                        'key' => '_rma_invoice_status',
+                        'value' => '',
+					'compare' => '!=',
+                    )
+			);
+		}
+
+		// Set the meta query to the complete, altered query
+            $query->set('meta_query',$meta_query);
+
+	}
+
+
+
+		/**
+		 * User Profile Info
+		 * Show invoice information to users on their profile page.
+		 */
+
+		/**
+		 * Register new endpoint to use inside My Account page.
+		 *
+		 * @see https://developer.wordpress.org/reference/functions/add_rewrite_endpoint/
+		 */
+	function my_invoices_endpoint() {
+		add_rewrite_endpoint( 'invoices', EP_ROOT | EP_PAGES );
+	}
+
+		/**
+		 * Add new query var.
+		 *
+		 * @param array $vars
+		 * @return array
+		 */
+	function my_invoices_query_vars( $vars ) {
+		$vars[] = 'invoices';
+
+		return $vars;
+	}
+
+		/**
+		 * Insert the new endpoint into the My Account menu.
+		 *
+		 * @param array $items
+		 * @return array
+		 */
+	function my_invoices_my_account_menu_items( $items ) {
+
+		$items = RMA_WC_Frontend::array_insert( $items, 'orders', 'invoices', __( 'Invoices', 'rma-wc' ) );
+
+		return $items;
+	}
+
+
+		/**
+		 * Add page templates.
+		 *
+         * @param  array  $templates  The list of page templates
+		 *
+		 * @return array  $templates  The modified list of page templates
+		 */
+        function add_account_invoices_template ( $templates ) {
+            $templates[plugin_dir_path( __FILE__ ) . 'templates/invoices.php'] = __( 'Page Template From Plugin', 'text-domain' );
+
+		return $templates;
+	}
+
+
+		/**
+		 * Endpoint HTML content.
+		 */
+	function my_invoices_endpoint_content() {
+
+		$invoice_data = array();
+
+            $user_id = get_current_user_id();
+		$rma_customer_id = get_user_meta( $user_id, 'rma_customer', true );
+
+            if( ! empty( $rma_customer_id ) ) {
+
+			$RMA_WC_API = new RMA_WC_API();
+
+			$customer_info = $RMA_WC_API->get_customer( $rma_customer_id );
+                $invoices = $RMA_WC_API->get_customer_invoices( $rma_customer_id );
+
+                $invoice_data[ 'customer_info'] = $customer_info;
+                $invoice_data['invoices'] = $invoices;
+
+			unset( $RMA_WC_API );
+                load_template(plugin_dir_path(__FILE__) . '../templates/invoices.php', null, $invoice_data); // TODO: Do real templating
+            }
+            else {
+                printf ('<div class="warning">%1s</div>', esc_html_e( 'This user does not have an account in the accounting system.', 'rma-wc' ));
+
+		}
+	}
+
+		/**
+		 * Endpoint PDF Download
+		 *
+		 * Requires a nonce _wpnonce, 'download-pdf-nonce-' . $invoice_number
+         * 
+		 */
+	public function invoice_pdf_download() {
+
+		$path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+
+		if ( ! str_ends_with( rtrim( wc_get_endpoint_url( 'invoices/pdf', '', wc_get_page_permalink( 'myaccount' ) ), '/' ), dirname( $path ) ) ) {
+			return;
+		}
+
+		$invoice_number = strtoupper( sanitize_key( basename( $path ) ) );
+            $nonce = $_REQUEST['_wpnonce'];
+		if ( ! wp_verify_nonce( $nonce, 'download-pdf-nonce-' . $invoice_number ) ) {
+			// This nonce is not valid.
+			wp_die( __( 'Security check failed', 'textdomain' ) );
+		} else {
+			// The nonce was valid.
+			$RMA_WC_API = new RMA_WC_API();
+                $pdf_data = $RMA_WC_API->get_invoice_pdf( $invoice_number );
+			unset( $RMA_WC_API );
+
+                http_response_code(200);
+                header("Content-Type: application/pdf");
+                header('Content-Length: ' . mb_strlen($pdf_data, '8bit'));
+			echo $pdf_data;
+			exit;
+		}
+	}
+
+}

--- a/rma-wc-main.php
+++ b/rma-wc-main.php
@@ -11,6 +11,7 @@ include_once RMA_WC_PFAD . 'classes/class-RMA_WC_Frontend.php';
 include_once RMA_WC_PFAD . 'classes/class-RMA_WC_Collective_Invoicing.php';
 include_once RMA_WC_PFAD . 'classes/class-RMA_WC_Payment.php';
 include_once RMA_WC_PFAD . 'classes/class-RMA_WC_Rental_And_Booking.php';
+include_once RMA_WC_PFAD . 'classes/class-RMA_WC_Invoice.php';
 
 // LOAD BACKEND ////////////////////////////////////////////////////////////////
 
@@ -55,3 +56,6 @@ if ( class_exists( 'RedQ_Rental_And_Bookings' ) ) {
 	$RMA_RnB = new RMA_WC_Rental_And_Booking();
 
 }
+
+// RMA Invoice Status
+new RMA_WC_Invoice();


### PR DESCRIPTION
With this merge request the invoice status is updated in the background and shown in the order lists. It allows order queries by invoice number and adds a status columns to the order admin view.

For the (logged in) users it also:
- Shows their invoices in my-account
- Provides the option to download the invoice PDF
- Creates a WC Notice if there are unpaid invoices

**Note:** As a separate commit there is a change to extend the timeout for API calls. The RMA API does not seem to support paging, so we don't have another way to ensure a save REST response. 
The preferrable solution would of course be to add paging capabilities to the API itself ;-).