### PR TITLE
fix API logging static call usage

### DIFF
--- a/classes/class-RMA_WC_API.php
+++ b/classes/class-RMA_WC_API.php
@@ -13,7 +13,7 @@ if ( !class_exists('RMA_WC_API') ) {
 			// define constants only if they are not defined yet
 			// for this we check for two common constants which definitely needs to be defined
 			if ( !defined( 'RMA_MANDANT' ) || !defined( 'RMA_INVOICE_PREFIX' ) )
-				self::define_constants();
+				$this->define_constants();
 
 		}
 
@@ -999,7 +999,7 @@ if ( !class_exists('RMA_WC_API') ) {
 		 *
 		 * @return bool
 		 */
-		public function write_log( &$values ): bool {
+		public static function write_log( &$values ): bool {
 
 			If( ! function_exists( 'wc_get_logger' ) || empty( $values ) ) {
 				return false;
@@ -1036,7 +1036,7 @@ if ( !class_exists('RMA_WC_API') ) {
 					wc_get_logger()->error( $message, $args );
 
 					// send email on error
-					if ( SENDLOGEMAIL ) $this->send_log_email($values);
+					if ( SENDLOGEMAIL ) self::send_log_email($values);
 
 					break;
 
@@ -1058,7 +1058,7 @@ if ( !class_exists('RMA_WC_API') ) {
 		 *
 		 * @return bool
 		 */
-		public function send_log_email( &$values ): bool {
+		public static function send_log_email( &$values ): bool {
 
 			ob_start();
 			include( plugin_dir_path( __FILE__ ) . '../templates/email/error-email-template.php');


### PR DESCRIPTION
Make logging helpers static to match their static call sites and prevent PHP fatals. Also call define_constants() via instance context in the constructor for consistency.

PHP 8+ compatibility...

Co-Authored by cursorAI