### PR TITLE
Guard guest-customer setting access during invoice creation.

### DIFF
--- a/classes/class-RMA_WC_API.php
+++ b/classes/class-RMA_WC_API.php
@@ -509,7 +509,7 @@ if ( !class_exists('RMA_WC_API') ) {
 
 				$settings = get_option('wc_rma_settings');
 
-				if ( 1 == $settings[ 'rma-create-guest-customer' ] ) {
+				if ( 1 == ( $settings[ 'rma-create-guest-customer' ] ?? 0 ) ) {
 
 					$rma_customer_id = (new RMA_WC_API)->create_rma_customer('order', $order_id );
 


### PR DESCRIPTION
This prevents undefined array key errors when rma-create-guest-customer is not present in wc_rma_settings.